### PR TITLE
Updated Dashboard.dart for border radius issue

### DIFF
--- a/lib/menu_dashboard_layout/dashboard.dart
+++ b/lib/menu_dashboard_layout/dashboard.dart
@@ -32,7 +32,7 @@ class Dashboard extends StatelessWidget {
         scale: scaleAnimation,
         child: Material(
           animationDuration: duration,
-          borderRadius: BorderRadius.all(Radius.circular(40)),
+          borderRadius: isCollapsed ? BorderRadius.circular(0) : BorderRadius.circular(40),
           elevation: 8,
           child: child,
         ),


### PR DESCRIPTION
Even when being on main material page border radius was 40 so changed it dynamically to 0 when on main page and 40 when on side bar panel.